### PR TITLE
Fix incorrect regex

### DIFF
--- a/src/main/java/com/collaborne/operations/tomcat/AWSRemoteIpValve.java
+++ b/src/main/java/com/collaborne/operations/tomcat/AWSRemoteIpValve.java
@@ -184,7 +184,7 @@ public class AWSRemoteIpValve extends RemoteIpValve {
 
 		// Finally, add the remaining octets as "any"
 		while (i < 4) {
-			prefixBuilder.append("([1-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])");
+			prefixBuilder.append("([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])");
 			if (i < 3) {
 				prefixBuilder.append("\\.");
 			}

--- a/src/test/java/com/collaborne/operations/tomcat/AWSRemoteIpValveRegexTest.java
+++ b/src/test/java/com/collaborne/operations/tomcat/AWSRemoteIpValveRegexTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright © 2016 Collaborne B.V. (opensource@collaborne.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.collaborne.operations.tomcat;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AWSRemoteIpValveRegexTest {
+
+  public static final String REMOTE_ADDR = "1.2.3.4";
+  public static final String[] REAL_CLOUDFRONT_ADDRESSES = {
+      "130.176.0.93",
+      "143.204.194.179",
+  };
+  private static final String A_LOAD_BALANCER = "192.168.1.1";
+  private static AWSRemoteIpValve valve = new AWSRemoteIpLastValve(new AssertingNoOpValve(REMOTE_ADDR));
+
+  @BeforeAll
+  public static void init() throws IOException {
+    valve.updateIpRanges();
+  }
+
+  @Test
+  public void testAddresses() throws Exception {
+    for (String cloudfrontAddress : REAL_CLOUDFRONT_ADDRESSES) {
+      MockRequest request = createMockRequest(cloudfrontAddress);
+      valve.invoke(request, null);
+    }
+  }
+
+  private MockRequest createMockRequest(String cloudfrontAddress) {
+    MockRequest request = new MockRequest();
+    request.setRemoteAddr(A_LOAD_BALANCER);
+    request.setRemoteHost(A_LOAD_BALANCER);
+    request.setServerPort(8080);
+    request.setScheme("https");
+    request.addHeader("X-Forwarded-For", REMOTE_ADDR+","+cloudfrontAddress);
+    return request;
+  }
+
+}


### PR DESCRIPTION
AWS has the range 130.176.0.0/16 added to their list, but when receiving traffic from 130.176.0.93 (Cloudfront), the IP wasn't trusted. This fixes the regex and adds a test.