### PR TITLE
Fix ArrayIndexOutOfBoundsException for /32 range

### DIFF
--- a/src/test/java/com/collaborne/operations/tomcat/AWSRemoteIpValveRegexCidr32Test.java
+++ b/src/test/java/com/collaborne/operations/tomcat/AWSRemoteIpValveRegexCidr32Test.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright © 2016 Collaborne B.V. (opensource@collaborne.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.collaborne.operations.tomcat;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+class AWSRemoteIpValveRegexCidr32Test {
+
+  public static final String REMOTE_ADDR = "1.2.3.4";
+  public static final String[] REAL_CLOUDFRONT_ADDRESSES = {
+      "52.73.10.190",
+  };
+  private static final String A_LOAD_BALANCER = "192.168.1.1";
+  private static AWSRemoteIpValve valve = new AWSRemoteIpLastValve(new AssertingNoOpValve(REMOTE_ADDR));
+
+  @BeforeAll
+  public static void init() throws IOException {
+    valve.setIpRangesUrl("file:test-range-with-cidr-32.json");
+    valve.updateIpRanges();
+  }
+
+  @Test
+  public void testAddresses() throws Exception {
+    for (String cloudfrontAddress : REAL_CLOUDFRONT_ADDRESSES) {
+      MockRequest request = createMockRequest(cloudfrontAddress);
+      valve.invoke(request, null);
+    }
+  }
+
+  private MockRequest createMockRequest(String cloudfrontAddress) {
+    MockRequest request = new MockRequest();
+    request.setRemoteAddr(A_LOAD_BALANCER);
+    request.setRemoteHost(A_LOAD_BALANCER);
+    request.setServerPort(8080);
+    request.setScheme("https");
+    request.addHeader("X-Forwarded-For", REMOTE_ADDR+","+cloudfrontAddress);
+    return request;
+  }
+
+}

--- a/test-range-with-cidr-32.json
+++ b/test-range-with-cidr-32.json
@@ -1,0 +1,14 @@
+{
+  "syncToken": "1594041552",
+  "createDate": "2020-07-06-13-19-12",
+  "prefixes": [
+    {
+      "ip_prefix": "52.73.10.190/32",
+      "region": "us-east-1",
+      "service": "CLOUDFRONT",
+      "network_border_group": "us-east-1"
+    }
+  ],
+  "ipv6_prefixes": [
+  ]
+}


### PR DESCRIPTION
Last week AWS updated the `ip-ranges.json` with /32 ranges, causing the valve to throw
```
java.lang.ArrayIndexOutOfBoundsException: Index 4 out of bounds for length 4

	at com.collaborne.operations.tomcat.AWSRemoteIpValve.appendRangeRegularExpression(AWSRemoteIpValve.java:172)
	at com.collaborne.operations.tomcat.AWSRemoteIpValve.updateIpRanges(AWSRemoteIpValve.java:251)
	at com.collaborne.operations.tomcat.AWSRemoteIpValveRegexExactIpTest.init(AWSRemoteIpValveRegexExactIpTest.java:35)
```

This should fix it, and also allows for using local cached files of the `ip-ranges.json` file.